### PR TITLE
Update SketchCanvas ref type and prop for SignatureCanvas

### DIFF
--- a/__tests__/CoreStore.noteEdit.test.ts
+++ b/__tests__/CoreStore.noteEdit.test.ts
@@ -277,8 +277,9 @@ describe('CoreStore - Note Editing', () => {
 
   describe('createNote - sketch type', () => {
     it('should create a sketch note with sketchDataUri', async () => {
-      const sketchData = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
-      
+      const sketchData =
+        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
       await coreStore.createNote({
         type: 'sketch',
         title: 'My Sketch',
@@ -317,8 +318,9 @@ describe('CoreStore - Note Editing', () => {
 
     it('should require title for sketch notes to be saveable', async () => {
       // Test that sketch notes require a title
-      const sketchData = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
-      
+      const sketchData =
+        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
       // Should be able to create sketch note with title and sketch data
       await coreStore.createNote({
         type: 'sketch',
@@ -339,7 +341,7 @@ describe('CoreStore - Note Editing', () => {
       // The UI tracks hasDrawn state and enables save button
       // When save is clicked, readSignature() is called to get the data
       const sketchData = 'data:image/png;base64,captured';
-      
+
       await coreStore.createNote({
         type: 'sketch',
         title: 'Drawn Note',

--- a/src/components/SketchCanvas.tsx
+++ b/src/components/SketchCanvas.tsx
@@ -1,6 +1,8 @@
 import React, { useRef, useImperativeHandle, forwardRef } from 'react';
 import { StyleSheet, View, PanResponder } from 'react-native';
-import SignatureCanvas from 'react-native-signature-canvas';
+import SignatureCanvas, {
+  SignatureViewRef,
+} from 'react-native-signature-canvas';
 import { COLORS } from '../theme';
 
 interface SketchCanvasProps {
@@ -33,7 +35,7 @@ export interface SketchCanvasHandle {
  */
 const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(
   ({ onSketchSave, initialSketch, onClear, onBegin }, forwardedRef) => {
-    const ref = useRef<SignatureCanvas | null>(null);
+    const ref = useRef<SignatureViewRef | null>(null);
 
     useImperativeHandle(forwardedRef, () => ({
       readSignature: () => {
@@ -69,7 +71,7 @@ const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(
         onMoveShouldSetPanResponderCapture: () => true,
         onPanResponderTerminationRequest: () => false,
         onShouldBlockNativeResponder: () => true,
-      })
+      }),
     ).current;
 
     // Web style for the canvas
@@ -90,7 +92,11 @@ const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(
   }`;
 
     return (
-      <View style={styles.container} collapsable={false} {...panResponder.panHandlers}>
+      <View
+        style={styles.container}
+        collapsable={false}
+        {...panResponder.panHandlers}
+      >
         <SignatureCanvas
           ref={ref}
           onOK={handleOK}
@@ -101,11 +107,11 @@ const SketchCanvas = forwardRef<SketchCanvasHandle, SketchCanvasProps>(
           penColor={COLORS.PRIMARY_DARK}
           dataURL={initialSketch}
           webviewContainerStyle={styles.webviewContainer}
-          scrollEnabled={false}
+          scrollable={false}
         />
       </View>
     );
-  }
+  },
 );
 
 SketchCanvas.displayName = 'SketchCanvas';


### PR DESCRIPTION
Changed the ref type in SketchCanvas from SignatureCanvas to SignatureViewRef to match the updated react-native-signature-canvas API. Also replaced the deprecated 'scrollEnabled' prop with 'scrollable'. Minor formatting improvements were made in test files for consistency.